### PR TITLE
Extract components list from jsx

### DIFF
--- a/packages/svgo-jsx/.gitignore
+++ b/packages/svgo-jsx/.gitignore
@@ -1,1 +1,1 @@
-fixtures/output
+fixtures/output*

--- a/packages/svgo-jsx/README.md
+++ b/packages/svgo-jsx/README.md
@@ -68,6 +68,7 @@ Frameworks handle attributes differently. React requires camelised "xlink:href",
   targetFile: string,
   componentName: string,
   jsx: string,
+  components: string[]
 }) => string;
 ```
 
@@ -141,10 +142,13 @@ SVGO plugins option to enable optimisations
 ### convertSvgToJsx
 
 ```js
-({ file: string, svg: string, svgProps, plugins = [] }) => string;
+({ file: string, svg: string, svgProps, plugins = [] }) => {
+  jsx: string,
+  components: string[]
+};
 ```
 
-Produces jsx without component wrapper.
+Produces jsx without component wrapper and list of components (capitalized tags).
 
 - target: same string as above
 - file: used for error reporting

--- a/packages/svgo-jsx/fixtures/components.config.js
+++ b/packages/svgo-jsx/fixtures/components.config.js
@@ -1,0 +1,41 @@
+const template = ({
+  sourceFile,
+  componentName,
+  jsx,
+  components,
+}) => `// Generated from ${sourceFile}
+
+import {${components.join(", ")}} from 'react-custom'
+
+export const ${componentName} = (props) => {
+  return (
+    ${jsx}
+  );
+}
+`;
+
+export const config = {
+  inputDir: "./input",
+  outputDir: "./output-components",
+  template,
+  plugins: [
+    {
+      type: "visitor",
+      name: "capital-tags",
+      fn: () => {
+        return {
+          element: {
+            enter: (node) => {
+              if (node.name === "svg") {
+                node.name = "Svg";
+              }
+              if (node.name === "circle") {
+                node.name = "Circle";
+              }
+            },
+          },
+        };
+      },
+    },
+  ],
+};

--- a/packages/svgo-jsx/fixtures/input/cog.svg
+++ b/packages/svgo-jsx/fixtures/input/cog.svg
@@ -1,6 +1,7 @@
 <svg fill="black" width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
     <circle cx="12" cy="12" r="10" fill="url(#gradient)" />
+    <circle cx="24" cy="12" r="10" fill="url(#gradient)" />
   </g>
   <defs>
     <linearGradient id="gradient" x1="4.083" y1="23.97" x2="23.15" y2="4.904" gradientUnits="userSpaceOnUse">

--- a/packages/svgo-jsx/svgo-jsx-cli.js
+++ b/packages/svgo-jsx/svgo-jsx-cli.js
@@ -77,7 +77,7 @@ const run = async () => {
         count += 1;
         const svgFile = path.join(inputDir, dirent.name);
         const svg = await fs.readFile(svgFile, "utf-8");
-        const jsx = convertSvgToJsx({
+        const { jsx, components } = convertSvgToJsx({
           file: path.relative(configDir, svgFile),
           svg,
           svgProps: config.svgProps || defaultSvgProps,
@@ -95,6 +95,7 @@ const run = async () => {
           targetFile: path.relative(configDir, jsxFile),
           componentName,
           jsx,
+          components
         });
         await fs.mkdir(outputDir, { recursive: true });
         await fs.writeFile(jsxFile, component);

--- a/packages/svgo-jsx/svgo-jsx-cli.test.js
+++ b/packages/svgo-jsx/svgo-jsx-cli.test.js
@@ -24,7 +24,10 @@ test("cli converts svg into component with default config", async () => {
 export const Cog = (props) => {
   return (
     <svg width=\\"24\\" height=\\"24\\" viewBox=\\"0 0 24 24\\" {...props}>
-      <circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"url(#cog_svg__a)\\" />
+      <g fill=\\"url(#cog_svg__a)\\">
+        <circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" />
+        <circle cx=\\"24\\" cy=\\"12\\" r=\\"10\\" />
+      </g>
       <defs>
         <linearGradient
           id=\\"cog_svg__a\\"
@@ -73,6 +76,7 @@ export const Cog = (props) => {
     >
       <g>
         <Circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"url(#gradient)\\" />
+        <Circle cx=\\"24\\" cy=\\"12\\" r=\\"10\\" fill=\\"url(#gradient)\\" />
       </g>
       <defs>
         <linearGradient

--- a/packages/svgo-jsx/svgo-jsx-cli.test.js
+++ b/packages/svgo-jsx/svgo-jsx-cli.test.js
@@ -44,3 +44,52 @@ export const Cog = (props) => {
 "
 `);
 });
+
+test("jsx components list is passed to template", async () => {
+  const cli = path.join(dir, "./svgo-jsx-cli.js");
+  const config = path.join(dir, "./fixtures/components.config.js");
+  const { stdout, stderr } = await exec(`node ${cli} ${config}`);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/Compiled 1 icons in \d+ms/);
+  const generatedFile = path.join(dir, "./fixtures/output-components/cog.js");
+  const generated = prettier.format(await fs.readFile(generatedFile, "utf-8"), {
+    filepath: generatedFile,
+  });
+  expect(generated).toMatchInlineSnapshot(`
+"// Generated from input/cog.svg
+
+import { Svg, Circle } from \\"react-custom\\";
+
+export const Cog = (props) => {
+  return (
+    <Svg
+      fill=\\"black\\"
+      width=\\"24\\"
+      height=\\"24\\"
+      viewBox=\\"0 0 24 24\\"
+      version=\\"1.1\\"
+      xmlns=\\"http://www.w3.org/2000/svg\\"
+      xmlnsXlink=\\"http://www.w3.org/1999/xlink\\"
+    >
+      <g>
+        <Circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\" fill=\\"url(#gradient)\\" />
+      </g>
+      <defs>
+        <linearGradient
+          id=\\"gradient\\"
+          x1=\\"4.083\\"
+          y1=\\"23.97\\"
+          x2=\\"23.15\\"
+          y2=\\"4.904\\"
+          gradientUnits=\\"userSpaceOnUse\\"
+        >
+          <stop stopColor=\\"#00C1DE\\" />
+          <stop offset=\\"1\\" stopColor=\\"#00C1DE\\" stopOpacity=\\"0\\" />
+        </linearGradient>
+      </defs>
+    </Svg>
+  );
+};
+"
+`);
+});

--- a/packages/svgo-jsx/svgo-jsx.js
+++ b/packages/svgo-jsx/svgo-jsx.js
@@ -104,7 +104,7 @@ const convertXastToJsx = (node, target, svgProps, components) => {
       const name = node.name;
       // collect all components names
       if (name.startsWith(name[0].toUpperCase())) {
-        components.push(name);
+        components.add(name);
       }
       const attributes = convertAttributes(node, target, svgProps);
       if (node.children.length === 0) {
@@ -174,11 +174,11 @@ export const convertSvgToJsx = ({
     throw Error(error);
   }
   try {
-    const components = [];
+    const components = new Set();
     const jsx = convertXastToJsx(xast, target, svgProps, components);
     return {
       jsx,
-      components,
+      components: Array.from(components),
     };
   } catch (error) {
     throw Error(`${error.message}\nin ${file}`);


### PR DESCRIPTION
Ref https://github.com/svg/svgo-components/issues/3

React native and other custom targets support requires component names
to be extracted from jsx. For example Svg, Rect and Circle. The list
allow to generate import statement.

```js
const template = ({ sourceFile, componentName, jsx, components }) => `
import {${components.join(", ")}} from 'react-custom'

export const ${componentName} = (props) => {
  return (
    ${jsx}
  );
}
`;
```

```js
import { Svg, Rect, Circle } from "react-custom";
```

cc @jeetiss