### PR TITLE
Allow to specify custom target

### DIFF
--- a/packages/svgo-jsx/README.md
+++ b/packages/svgo-jsx/README.md
@@ -159,6 +159,68 @@ Produces jsx without component wrapper and list of components (capitalized tags)
 - svgProps: same object as above without any default
 - plugins: svgo plugins array without any default
 
+## Working with custom renderer
+
+Custom renderer is a SVGO plugin which prepares jsx to any not supported out of the box renderers
+by converting tag names and attributes.
+
+```js
+const customTargetPlugin = {
+  type: "visitor",
+  name: "svgo-jsx-custom",
+  fn: () => {
+    const customTags = {
+      svg: "Svg"
+    }
+    const customAttributes = {
+      "xlink:href": "xlinkHref"
+    }
+    return {
+      element: {
+        enter: (node) => {
+          node.name = customTags[node.name] ?? node.name;
+          // attributes recreation is used to preserve order
+          const newAttributes = {};
+          for (const [name, value] of Object.entries(node.attributes)) {
+            newAttributes[customAttributes[name] ?? name] = value;
+          }
+          node.attributes = newAttributes;
+        },
+      },
+    };
+  },
+};
+
+const template = ({ componentName, jsx, components }) => `
+import {${components.join(", ")}} from 'react-custom'
+
+export const ${componentName} = () => {
+  return (
+    ${jsx}
+  );
+}
+`;
+
+export const config = {
+  ...
+  target: 'custom',
+  template,
+  plugins: [
+    {
+      name: "preset-default",
+      params: {
+        overrides: {
+          removeViewBox: false,
+        },
+      },
+    },
+    { name: "removeXMLNS" },
+    { name: "prefixIds" },
+    customTargetPlugin
+  ]
+};
+```
+
 ## License and Copyright
 
 This software is released under the terms of the MIT license.

--- a/packages/svgo-jsx/README.md
+++ b/packages/svgo-jsx/README.md
@@ -54,11 +54,14 @@ A path relative to config file with SVG files.
 
 A path relative to config svgo-jsx will write generated components into.
 
-**target**: optional "react-dom" or "preact"
+**target**: optional "react-dom", "preact" or "custom"
 
 Default: "react-dom"
 
 Frameworks handle attributes differently. React requires camelised "xlink:href", preact prefer modern "href". Here you can specify desired framework.
+
+"custom" target does not transform tags and attributes and allows to write svgo plugin
+to generate components for custom renerer.
 
 **template**: optional function
 

--- a/packages/svgo-jsx/svgo-jsx.test.js
+++ b/packages/svgo-jsx/svgo-jsx.test.js
@@ -224,8 +224,35 @@ test("support preact and ignores namespaced attributes", () => {
   `);
 });
 
+test("support custom target without transforming attributes", () => {
+  const { jsx, components } = convertSvgToJsx({
+    target: "custom",
+    file: "./test.svg",
+    svg: `
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24" xmlns:title="Title">
+          <rect x="0" y="0" width="24" height="24" fill-opacity="0.5" />
+          <use xlink:href="#id" />
+        </svg>
+      `,
+  });
+  expect(format(jsx)).toMatchInlineSnapshot(`
+"<svg
+  xmlns=\\"http://www.w3.org/2000/svg\\"
+  version=\\"1.1\\"
+  width=\\"24\\"
+  height=\\"24\\"
+  viewBox=\\"0 0 24 24\\"
+>
+  <rect x=\\"0\\" y=\\"0\\" width=\\"24\\" height=\\"24\\" fill-opacity=\\"0.5\\" />
+  <use />
+</svg>;
+"
+`);
+});
+
 test("output list of used components", () => {
   const { jsx, components } = convertSvgToJsx({
+    target: "custom",
     file: "./test.svg",
     svg: `
         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24" xmlns:title="Title">
@@ -257,14 +284,13 @@ test("output list of used components", () => {
   expect(format(jsx)).toMatchInlineSnapshot(`
 "<Svg
   xmlns=\\"http://www.w3.org/2000/svg\\"
-  xmlnsXlink=\\"http://www.w3.org/1999/xlink\\"
   version=\\"1.1\\"
   width=\\"24\\"
   height=\\"24\\"
   viewBox=\\"0 0 24 24\\"
 >
-  <Rect x=\\"0\\" y=\\"0\\" width=\\"24\\" height=\\"24\\" fillOpacity=\\"0.5\\" />
-  <use xlinkHref=\\"#id\\" />
+  <Rect x=\\"0\\" y=\\"0\\" width=\\"24\\" height=\\"24\\" fill-opacity=\\"0.5\\" />
+  <use />
 </Svg>;
 "
 `);


### PR DESCRIPTION
Custom target prevent svgo-jsx from transforming tags and attributes.
Can be useful for projects like react-pdf.

You can write svgo plugin to transform tags and attributes for your
renderer.

```js
const yourFrameworkTargetPlugin = {
  type: "visitor",
  name: "svgo-jsx-your-framework",
  fn: () => {
    const yourFrameworkTags = {
      svg: "Svg"
    }
    const yourFrameworkAttributes = {
      "xlink:href": "xlinkHref"
    }
    return {
      element: {
        enter: (node) => {
          node.name = yourFrameworkTags[node.name] ?? node.name;
          // attributes recreation is used to preserve order
          const newAttributes = {};
          for (const [name, value] of Object.entries(node.attributes)) {
            newAttributes[yourFrameworkAttributes[name] ?? name] = value;
          }
          node.attributes = newAttributes;
        },
      },
    };
  },
};

export const config = {
  ...
  target: 'custom',
  plugins: [
    {
      name: "preset-default",
      params: {
        overrides: {
          removeViewBox: false,
        },
      },
    },
    { name: "removeXMLNS" },
    { name: "prefixIds" },
    yourFrameworkTargetPlugin
  ]
};
```